### PR TITLE
fix: proxy rewrite 제거, /api 경로 유지

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
         target: 'https://sadajobe.shop',
         changeOrigin: true,
         secure: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
fix: proxy rewrite 제거, /api 경로 유지

기존 proxy rewrite에서 /api 경로를 제거하고 있었으나, api 문서를 재확인 했을 때, 모든 경로에서 /api가 포함되어 있어 rewrite를 제거하였습니다. 